### PR TITLE
Update deploy.ts for sepolia

### DIFF
--- a/random-svg-nft/scripts/deploy.ts
+++ b/random-svg-nft/scripts/deploy.ts
@@ -4,18 +4,18 @@ async function main() {
   const [deployer] = await ethers.getSigners();
 
   console.log(
-    `Attempting to deploy EmojiNFT smart contract on Rinkeby network from ${deployer.address}`
+    `Attempting to deploy EmojiNFT smart contract on Sepolia network from ${deployer.address}`
   );
 
   const numberOfBlockConfiramtions = 6;
   /**
-   * https://docs.chain.link/docs/vrf-contracts/#rinkeby-testnet
+   * https://docs.chain.link/docs/vrf-contracts/#sepolia-testnet
    *
-   * Rinkeby Faucets
+   * Sepolia Faucets
    *
-   * Testnet LINK is available from https://faucets.chain.link/rinkeby
-   * Testnet ETH is available from: https://faucets.chain.link/rinkeby
-   * Backup Testnet ETH Faucets: https://rinkeby-faucet.com/, https://app.mycrypto.com/faucet
+   * Testnet LINK is available from https://faucets.chain.link/sepolia
+   * Testnet ETH is available from: https://faucets.chain.link/sepolia
+   * Backup Testnet ETH Faucets: https://sepolia-faucet.com/, https://app.mycrypto.com/faucet
    */
   const vrfCoordinator = `0x6168499c0cFfCaCD319c818142124B7A15E857ab`;
   const subscriptionId = process.env.SUBSCRIPTION_ID!;


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-turbo-2024-04-09). Be mindful of hallucinations and verify accuracy.**

## Why
Updates deployment script to target the Sepolia network instead of Rinkeby, aligning resources and documentation URLs accordingly.

## What
**deploy.ts**
  - Changed network from Rinkeby to Sepolia in deployment message
  - Updated URLs from Rinkeby to Sepolia for VRF contracts, faucets, and testnet resources
