### PR TITLE
Added a utility contract and a JS script for upkeep interactions.

### DIFF
--- a/upkeep-interactions/custom-logic-upkeep/README.md
+++ b/upkeep-interactions/custom-logic-upkeep/README.md
@@ -1,0 +1,11 @@
+# Custom Logic Upkeep Interactions
+
+### UpkeepInteractions.sol
+
+A solidity contract showcasing the interaction with `AutomationRegistrar` and `KeeperRegistry` contracts, for **registration** of **Custom Logic Upkeep** and performing other operations like **pause upkeep**, **unpause upkeep**, **cancel upkeep**, **add funds to upkeep**, **withdraw funds from upkeep**, and **edit gas limit of upkeep**.
+
+**Note:** The upkeep that will be registered using the contract won't be visible in the [Automation UI](https://automation.chain.link/) because the `adminAddress` is being set to the address of the contract (not to any wallet).
+
+###  upkeepInteractions.js
+
+A script in JS containing the functions to interact with the registered **Custom Logic Upkeep**.

--- a/upkeep-interactions/custom-logic-upkeep/UpkeepInteractions.sol
+++ b/upkeep-interactions/custom-logic-upkeep/UpkeepInteractions.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/shared/interfaces/LinkTokenInterface.sol";
+import {AutomationCompatible} from "@chainlink/contracts/src/v0.8/AutomationCompatible.sol";
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+error LessThanMinimumAmount(uint256 required);
+error UpkeepIsAlreadyInPausedState();
+error UpkeepIsAlreadyInUnpausedOrActiveState();
+error UpkeepIsNotRegisteredYet();
+error UpkeepIsAlreadyCancelled();
+error UpkeepNeedsToBeCancelledFirst();
+
+struct RegistrationParams {
+    string name;
+    bytes encryptedEmail;
+    address upkeepContract;
+    uint32 gasLimit;
+    address adminAddress;
+    uint8 triggerType;
+    bytes checkData;
+    bytes triggerConfig;
+    bytes offchainConfig;
+    uint96 amount;
+}
+
+/**
+ * string name = "test upkeep";
+ * bytes encryptedEmail = 0x;
+ * address upkeepContract = 0x...;
+ * uint32 gasLimit = 500000;
+ * address adminAddress = 0x....;
+ * uint8 triggerType = 0;
+ * bytes checkData = 0x;
+ * bytes triggerConfig = 0x;
+ * bytes offchainConfig = 0x;
+ * uint96 amount = 1000000000000000000;
+ */
+interface AutomationRegistrarInterface {
+    function registerUpkeep(RegistrationParams calldata requestParams) external returns (uint256);
+}
+
+interface KeeperRegistryInterface {
+    function addFunds(uint256 id, uint96 amount) external;
+
+    function pauseUpkeep(uint256 id) external;
+
+    function unpauseUpkeep(uint256 id) external;
+
+    function cancelUpkeep(uint256 id) external;
+
+    function setUpkeepGasLimit(uint256 id, uint32 gasLimit) external;
+
+    function withdrawFunds(uint256 id, address to) external;
+}
+
+contract UpkeepIDConditionalExample is AutomationCompatible {
+    // Hardcoded for Eth-Sepolia network
+    LinkTokenInterface public constant LINK = LinkTokenInterface(0x779877A7B0D9E8603169DdbD7836e478b4624789);
+    AutomationRegistrarInterface public constant REGISTRAR =
+        AutomationRegistrarInterface(0xb0E49c5D0d05cbc241d68c05BC5BA1d1B7B72976);
+    KeeperRegistryInterface public constant KEEPER_REGISTRY =
+        KeeperRegistryInterface(0x86EFBD0b6736Bed994962f9797049422A3A8E8Ad);
+
+    uint256 public s_numberOfPerformUpkeepCallsForLatestUpkeep;
+    uint256 constant endDate = 1715781439;
+    uint256 public s_latestUpkeepId;
+    bool public s_isLatestUpkeepPaused;
+    bool public s_isLatestUpkeepCancelled;
+
+    // Note: The upkeep that will be registered here won't be visible in the Automation UI (https://automation.chain.link/) because the adminAddress is being set to the address of this contract (not to any wallet).
+    function registerUpkeep(string memory upkeepName, uint96 initialAmount, uint32 gasLimit) external {
+        s_numberOfPerformUpkeepCallsForLatestUpkeep = 0;
+        s_isLatestUpkeepPaused = false;
+        s_isLatestUpkeepCancelled = false;
+
+        bytes memory encryptedEmail = "";
+        address upkeepContract = address(this);
+        address adminAddress = address(this); // Note: Setting adminAddress as address of this contract, so as to have the authorization to call the management functions like pause, unpause, cancel, etc. as they can be called only by the admin.
+        uint8 triggerType = 0;
+        bytes memory checkData = "";
+        bytes memory triggerConfig = "";
+        bytes memory offchainConfig = "";
+
+        RegistrationParams memory params = RegistrationParams(
+            upkeepName,
+            encryptedEmail,
+            upkeepContract,
+            gasLimit,
+            adminAddress,
+            triggerType,
+            checkData,
+            triggerConfig,
+            offchainConfig,
+            initialAmount
+        );
+
+        // LINK must be approved for transfer - this can be done every time or once
+        // with an infinite approval
+        if (params.amount < 1e18) {
+            revert LessThanMinimumAmount(1e18);
+        }
+        LINK.approve(address(REGISTRAR), params.amount);
+        uint256 upkeepID = REGISTRAR.registerUpkeep(params);
+        if (upkeepID != 0) {
+            // DEV - Use the upkeepID however you see fit
+            s_latestUpkeepId = upkeepID;
+        } else {
+            revert("auto-approve disabled");
+        }
+    }
+
+    function addFundsToUpkeep(uint96 amount) external {
+        if (s_latestUpkeepId == 0) revert UpkeepIsNotRegisteredYet();
+        if (s_isLatestUpkeepCancelled) revert UpkeepIsAlreadyCancelled();
+        LINK.approve(address(KEEPER_REGISTRY), amount);
+        KEEPER_REGISTRY.addFunds(s_latestUpkeepId, amount);
+    }
+
+    function withdrawFundsFromUpkeep(address to) external {
+        if (s_latestUpkeepId == 0) revert UpkeepIsNotRegisteredYet();
+        if (!s_isLatestUpkeepCancelled) revert UpkeepNeedsToBeCancelledFirst();
+
+        KEEPER_REGISTRY.withdrawFunds(s_latestUpkeepId, to);
+    }
+
+    function pauseUpkeep() external {
+        if (s_latestUpkeepId == 0) revert UpkeepIsNotRegisteredYet();
+        if (s_isLatestUpkeepCancelled) revert UpkeepIsAlreadyCancelled();
+        if (s_isLatestUpkeepPaused) revert UpkeepIsAlreadyInPausedState();
+        KEEPER_REGISTRY.pauseUpkeep(s_latestUpkeepId);
+        s_isLatestUpkeepPaused = true;
+    }
+
+    function unpauseUpkeep() external {
+        if (s_latestUpkeepId == 0) revert UpkeepIsNotRegisteredYet();
+        if (s_isLatestUpkeepCancelled) revert UpkeepIsAlreadyCancelled();
+        if (!s_isLatestUpkeepPaused) {
+            revert UpkeepIsAlreadyInUnpausedOrActiveState();
+        }
+        KEEPER_REGISTRY.unpauseUpkeep(s_latestUpkeepId);
+        s_isLatestUpkeepPaused = false;
+    }
+
+    function editUpkeepGasLimit(uint32 newGasLimit) external {
+        if (s_latestUpkeepId == 0) revert UpkeepIsNotRegisteredYet();
+        if (s_isLatestUpkeepCancelled) revert UpkeepIsAlreadyCancelled();
+        KEEPER_REGISTRY.setUpkeepGasLimit(s_latestUpkeepId, newGasLimit);
+    }
+
+    function cancelUpkeep() external {
+        if (s_latestUpkeepId == 0) revert UpkeepIsNotRegisteredYet();
+        if (s_isLatestUpkeepCancelled) revert UpkeepIsAlreadyCancelled();
+        KEEPER_REGISTRY.cancelUpkeep(s_latestUpkeepId);
+        s_isLatestUpkeepPaused = false;
+        s_isLatestUpkeepCancelled = true;
+    }
+
+    function checkUpkeep(bytes memory /*checkdata*/ )
+        public
+        view
+        override
+        returns (bool upkeepNeeded, bytes memory /* performData*/ )
+    {
+        upkeepNeeded = block.timestamp > endDate && s_numberOfPerformUpkeepCallsForLatestUpkeep == 0;
+        return (upkeepNeeded, "");
+    }
+
+    function performUpkeep(bytes calldata /* performData */ ) external override {
+        (bool upkeepNeeded,) = checkUpkeep("");
+        if (upkeepNeeded) {
+            //    requestRandomWords();
+            s_numberOfPerformUpkeepCallsForLatestUpkeep += 1;
+        }
+    }
+}

--- a/upkeep-interactions/custom-logic-upkeep/upkeepInteractions.js
+++ b/upkeep-interactions/custom-logic-upkeep/upkeepInteractions.js
@@ -1,0 +1,168 @@
+const { ethers } = require('ethers');
+const url = "https://polygon-amoy.g.alchemy.com/v2/ALCHEMY_API_KEY";
+const provider = new ethers.JsonRpcProvider(url);
+
+const privateKey = "PRIVATE_KEY"; // should be of the wallet which has registered or created upkeep
+
+const wallet = new ethers.Wallet(privateKey, provider);
+
+// hardcoded for Polygon Amoy network
+const keeperRegistryAddress = "0x93C0e201f7B158F503a1265B6942088975f92ce7";
+
+const keeperRegistryAbi = [
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint96",
+                "name": "amount",
+                "type": "uint96"
+            }
+        ],
+        "name": "addFunds",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelUpkeep",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            }
+        ],
+        "name": "pauseUpkeep",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint32",
+                "name": "gasLimit",
+                "type": "uint32"
+            }
+        ],
+        "name": "setUpkeepGasLimit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            }
+        ],
+        "name": "unpauseUpkeep",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+];
+
+const linkTokenAddress = "0x0Fd9e8d3aF1aaee056EB9e802c3A762a667b1904";
+const linkApproveAbi = [
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "success",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]
+
+const keeperRegistry = new ethers.Contract(keeperRegistryAddress, keeperRegistryAbi, wallet);
+
+const linkTokenContract = new ethers.Contract(linkTokenAddress, linkApproveAbi, wallet);
+
+function pauseUpkeep(upkeepId) {
+    keeperRegistry.pauseUpkeep(upkeepId).then(async (tx) => {
+        const receipt = await tx.wait();
+        console.log("Upkeep is paused successfully. Tx hash:", receipt.hash);
+    });
+}
+
+function unpauseUpkeep(upkeepId) {
+    keeperRegistry.unpauseUpkeep(upkeepId).then(async (tx) => {
+        const receipt = await tx.wait();
+        console.log("Upkeep is unpaused successfully. Tx hash:", receipt.hash);
+    });
+}
+
+function cancelUpkeep(upkeepId) {
+    keeperRegistry.cancelUpkeep(upkeepId).then(async (tx) => {
+        const receipt = await tx.wait();
+        console.log("Upkeep is cancelled successfully. Tx hash:", receipt.hash);
+    });
+}
+
+function editGasLimit(upkeepId, newGasLimit) {
+    keeperRegistry.setUpkeepGasLimit(upkeepId, newGasLimit).then(async (tx) => {
+        const receipt = await tx.wait();
+        console.log(`Gas Limit of Upkeep has been edited to ${newGasLimit} successfully. Tx hash:`, receipt.hash);
+    });
+}
+
+function addFunds(upkeepId, amount) {
+
+    linkTokenContract.approve(keeperRegistryAddress, amount).then(async (tx) => {
+        const receipt = await tx.wait();
+        console.log(`${keeperRegistryAddress} has been approved to spend ${ethers.formatUnits(amount)} LINK. Tx hash:`, receipt.hash);
+
+        keeperRegistry.addFunds(upkeepId, amount).then(async (tx) => {
+            const receipt = await tx.wait();
+            console.log(`Added ${ethers.formatUnits(amount)} LINK to Upkeep. Tx hash:`, receipt.hash);
+        });
+    })
+
+}
+
+// pauseUpkeep("37911478868312250226697535921893891768210554547006807512283982890866473575540");
+// unpauseUpkeep("37911478868312250226697535921893891768210554547006807512283982890866473575540");
+// addFunds("37911478868312250226697535921893891768210554547006807512283982890866473575540", ethers.parseUnits("0.1"))
+// editGasLimit("37911478868312250226697535921893891768210554547006807512283982890866473575540", "600000")
+// cancelUpkeep("37911478868312250226697535921893891768210554547006807512283982890866473575540");


### PR DESCRIPTION
### Changes

- Added a solidity file named as `UpkeepInteractions.sol`, showcasing the interaction with `AutomationRegistrar` and `KeeperRegistry` contracts, for **registration** of **Custom Logic Upkeep** and performing other operations like **pause upkeep**, **unpause upkeep**, **cancel upkeep**, **add funds to upkeep**, **withdraw funds from upkeep**, and **edit gas limit of upkeep**.

- Added a script (`upkeepInteractions.js`) containing the functions to interact with the registered **Custom Logic Upkeep**.


### Motive

Initially, I've created that as a utility contract and shared as a [gist](https://gist.github.com/SyedAsadKazmi/80f6ccb5b01b3673b89532adc80bd79c) with the devs on **Chainlink Discord**, that are facing problems while registering and interacting with upkeep via contract.

Here are some of screenshots for the same:

![Screenshot 2024-07-26 at 3 05 48 PM](https://github.com/user-attachments/assets/de9a5100-9cbf-41db-8355-b1ecec529610)
![Screenshot 2024-07-26 at 3 07 21 PM](https://github.com/user-attachments/assets/278d12db-6242-4dc9-b60e-617bc1ccfaa8)
![Screenshot 2024-07-26 at 3 07 57 PM](https://github.com/user-attachments/assets/3df58da2-754d-474a-844d-f73df3f8d0b1)
![Screenshot 2024-07-26 at 3 09 07 PM](https://github.com/user-attachments/assets/77dc6e40-6de2-42a3-bd91-a960d2f8642b)
![Screenshot 2024-07-26 at 3 09 36 PM](https://github.com/user-attachments/assets/86160a13-9533-44b0-93f5-96bcad234bc1)


So, on Bharath's suggestion, I've decided to create this PR. The contract code could possibly be added into the [Register Upkeeps Programmatically](https://docs.chain.link/chainlink-automation/guides/register-upkeep-in-contract/#overview) section of the documentation, as it's a kind of extension of the same contract.

Kindly please review the PR, and let me know if any changes or add-ons are required from my end.

Thanks.