### PR TITLE
fix: add missing packages

### DIFF
--- a/vrf-arbitrum-gas-estimation/package.json
+++ b/vrf-arbitrum-gas-estimation/package.json
@@ -7,9 +7,13 @@
     },
     "dependencies": {
       "@arbitrum/sdk": "^v3.1.2",
+       "arb-shared-dependencies": "^1.0.0",
       "ts-node": "^10.8.1",
       "typescript": "^4.7.3"
     },
     "author": "",
-    "license": "ISC"
+    "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^22.7.5"
+    }
   }


### PR DESCRIPTION
`@types/node` for require in typescript
`arb-shared-dependencies` used in script, but not installed